### PR TITLE
Made synchronization object static

### DIFF
--- a/src/LinFu.IoC/Factories/SingletonFactory.cs
+++ b/src/LinFu.IoC/Factories/SingletonFactory.cs
@@ -13,7 +13,7 @@ namespace LinFu.IoC.Factories
         private static readonly Dictionary<object, T> _instances = new Dictionary<object, T>();
         private readonly Func<IFactoryRequest, T> _createInstance;
 
-        private readonly object _lock = new object();
+        private static readonly object _lock = new object();
 
         /// <summary>
         /// Initializes the factory class using the <paramref name="createInstance"/>


### PR DESCRIPTION
_lock was a instance variable, it must be static for SingletonFactory to be thread safe.
